### PR TITLE
Fix: init_tier_variation path and MediaUpload image parameter

### DIFF
--- a/src/Resources/MediaSpace.php
+++ b/src/Resources/MediaSpace.php
@@ -100,7 +100,7 @@ class MediaSpace extends Resource
         return $this->call('POST', 'media_space/upload_image', [
             RequestOptions::MULTIPART => [
                 [
-                    'name' => 'file',
+                    'name' => 'image',
                     'contents' => $image,
                     'filename' => $filename,
                 ],

--- a/src/Resources/Product.php
+++ b/src/Resources/Product.php
@@ -164,6 +164,24 @@ class Product extends Resource
         ]);
     }
 
+    public function updateStock($item_id, $params = [])
+    {
+        $params['item_id'] = $item_id;
+
+        return $this->call('POST', 'product/update_stock', [
+            RequestOptions::JSON => $params,
+        ]);
+    }
+
+    public function updatePrice($item_id, $params = [])
+    {
+        $params['item_id'] = $item_id;
+
+        return $this->call('POST', 'product/update_price', [
+            RequestOptions::JSON => $params,
+        ]);
+    }
+
     public function deleteItem($item_id)
     {
         return $this->call('POST', 'product/delete_item', [
@@ -181,7 +199,7 @@ class Product extends Resource
             'model' => $model,
         ];
 
-        return $this->call('POST', 'product/init_tier_variations', [
+        return $this->call('POST', 'product/init_tier_variation', [
             RequestOptions::JSON => $params,
         ]);
     }


### PR DESCRIPTION
1. Change the API path of init_titer_variation.
product/init_tier_variations => product/init_tier_variation

2. Change media_space/upload_image's parameter name.
     'file' => 'image'

3. Add updateStock and updatePrice method.